### PR TITLE
Add generic classes of StateMachine.NET project.

### DIFF
--- a/StateMachine.NET/GenericObject.cpp
+++ b/StateMachine.NET/GenericObject.cpp
@@ -1,0 +1,2 @@
+#include "stdafx.h"
+#include "GenericObject.h"

--- a/StateMachine.NET/GenericObject.cpp
+++ b/StateMachine.NET/GenericObject.cpp
@@ -29,5 +29,17 @@ namespace Generic {
 	{
 		return (HRESULT)exit((C)getManaged((native::Context*)context), (E)getManaged((native::Event*)event), (S)getManaged((native::State*)nextState));
 	}
+
+	generic<typename C>
+	HRESULT Event<C>::preHandleCallback(tsm::IContext* context)
+	{
+		return (HRESULT)preHandle((C)getManaged((native::Context*)context));
+	}
+
+	generic<typename C>
+	HRESULT Event<C>::postHandleCallback(tsm::IContext* context, HRESULT hr)
+	{
+		return (HRESULT)postHandle((C)getManaged((native::Context*)context), (HResult)hr);
+	}
 }
 }

--- a/StateMachine.NET/GenericObject.cpp
+++ b/StateMachine.NET/GenericObject.cpp
@@ -1,2 +1,33 @@
 #include "stdafx.h"
 #include "GenericObject.h"
+#include "NativeObjects.h"
+
+namespace tsm_NET {
+using namespace common;
+
+namespace Generic {
+
+	generic<typename C, typename E, typename S>
+	HRESULT State<C, E, S>::handleEventCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState)
+	{
+		S _nextState;
+		auto hr = handleEvent((C)getManaged((native::Context*)context), (E)getManaged((native::Event*)event), _nextState);
+		if(_nextState) {
+			*nextState = _nextState->get();
+		}
+		return (HRESULT)hr;
+	}
+
+	generic<typename C, typename E, typename S>
+	HRESULT State<C, E, S>::entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState)
+	{
+		return (HRESULT)entry((C)getManaged((native::Context*)context), (E)getManaged((native::Event*)event), (S)getManaged((native::State*)previousState));
+	}
+
+	generic<typename C, typename E, typename S>
+	HRESULT State<C, E, S>::exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState)
+	{
+		return (HRESULT)exit((C)getManaged((native::Context*)context), (E)getManaged((native::Event*)event), (S)getManaged((native::State*)nextState));
+	}
+}
+}

--- a/StateMachine.NET/GenericObject.h
+++ b/StateMachine.NET/GenericObject.h
@@ -56,6 +56,7 @@ public:
 };
 
 generic<typename C>
+	where C : tsm_NET::Context
 public ref class Event : public tsm_NET::Event
 {
 public:
@@ -67,12 +68,8 @@ public:
 #pragma endregion
 
 #pragma region Methods that call sub class with generic parameters.
-	virtual HResult preHandle(tsm_NET::Context^ context) override {
-		return preHandle((C)context);
-	}
-	virtual HResult postHandle(tsm_NET::Context^ context, HResult hr) override {
-		return postHandle((C)context, hr);
-	}
+	virtual HRESULT preHandleCallback(tsm::IContext* context) override;
+	virtual HRESULT postHandleCallback(tsm::IContext* context, HRESULT hr) override;
 #pragma endregion
 };
 }

--- a/StateMachine.NET/GenericObject.h
+++ b/StateMachine.NET/GenericObject.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "StateMachine.NET.h"
+
+namespace tsm_NET
+{
+namespace Generic
+{
+
+generic<typename E, typename S>
+public ref class Context : public tsm_NET::Context
+{
+public:
+	virtual ~Context() {}
+
+	HResult setup(S initialState, E event) { return tsm_NET::Context::setup((tsm_NET::State^)initialState, (tsm_NET::Event^)event); }
+	HResult setup(S initialState) { return tsm_NET::Context::setup((tsm_NET::State^)initialState); }
+	HResult shutdown(TimeSpan timeout) { return tsm_NET::Context::shutdown(timeout); }
+	HResult shutdown() { return tsm_NET::Context::shutdown(); }
+	HResult triggerEvent(E event) { return tsm_NET::Context::triggerEvent((tsm_NET::Event^)event); }
+	HResult handleEvent(E event) { return tsm_NET::Context::handleEvent((tsm_NET::Event^)event); }
+	HResult waitReady(TimeSpan timeout) { return tsm_NET::Context::waitReady(timeout); }
+	S getCurrentState() { return (S)tsm_NET::Context::getCurrentState(); }
+
+	property S CurrentState { S get() { return getCurrentState(); }}
+};
+
+generic<typename C, typename E, typename S>
+public ref class State : public tsm_NET::State
+{
+public:
+	State() : tsm_NET::State(nullptr) {}
+	State(S masterState) : tsm_NET::State((tsm_NET::State^)masterState) {}
+	~State() {}
+
+#pragma region Methods to be implemented by sub class.
+	virtual HResult handleEvent(C context, E event, S% nextState) { return HResult::Ok; }
+	virtual HResult entry(C context, E event, S previousState) { return HResult::Ok; }
+	virtual HResult exit(C context, E event, S nextState) { return HResult::Ok; }
+#pragma endregion
+
+#pragma region Methods that call sub class with generic parameters.
+	virtual HResult handleEvent(tsm_NET::Context^ context, tsm_NET::Event^ event, tsm_NET::State^% nextState) override {
+		S _nextState;
+		auto ret = handleEvent((C)context, (E)event, _nextState);
+		if(_nextState) {
+			nextState = (tsm_NET::State^)_nextState;
+		}
+		return ret;
+	}
+	virtual HResult entry(tsm_NET::Context^ context, tsm_NET::Event^ event, tsm_NET::State^ previousState) override {
+		return entry((C)context, (E)event, (S)previousState);
+	}
+	virtual HResult exit(tsm_NET::Context^ context, tsm_NET::Event^ event, tsm_NET::State^ nextState) override {
+		return exit((C)context, (E)event, (S)nextState);
+	}
+#pragma endregion
+
+	S getMasterState() { return (S)tsm_NET::State::getMasterState(); }
+
+	property S MasterState { S get() { return getMasterState(); }}
+};
+
+generic<typename C>
+public ref class Event : public tsm_NET::Event
+{
+public:
+	~Event() {}
+
+#pragma region Methods to be implemented by sub class.
+	virtual HResult preHandle(C context) { return HResult::Ok; }
+	virtual HResult postHandle(C context, HResult hr) { return hr; }
+#pragma endregion
+
+#pragma region Methods that call sub class with generic parameters.
+	virtual HResult preHandle(tsm_NET::Context^ context) override {
+		return preHandle((C)context);
+	}
+	virtual HResult postHandle(tsm_NET::Context^ context, HResult hr) override {
+		return postHandle((C)context, hr);
+	}
+#pragma endregion
+};
+}
+}

--- a/StateMachine.NET/GenericObject.h
+++ b/StateMachine.NET/GenericObject.h
@@ -28,6 +28,9 @@ public:
 };
 
 generic<typename C, typename E, typename S>
+	where C : tsm_NET::Context
+	where E : tsm_NET::Event
+	where S : tsm_NET::State
 public ref class State : public tsm_NET::State
 {
 public:
@@ -42,20 +45,9 @@ public:
 #pragma endregion
 
 #pragma region Methods that call sub class with generic parameters.
-	virtual HResult handleEvent(tsm_NET::Context^ context, tsm_NET::Event^ event, tsm_NET::State^% nextState) override {
-		S _nextState;
-		auto ret = handleEvent((C)context, (E)event, _nextState);
-		if(_nextState) {
-			nextState = (tsm_NET::State^)_nextState;
-		}
-		return ret;
-	}
-	virtual HResult entry(tsm_NET::Context^ context, tsm_NET::Event^ event, tsm_NET::State^ previousState) override {
-		return entry((C)context, (E)event, (S)previousState);
-	}
-	virtual HResult exit(tsm_NET::Context^ context, tsm_NET::Event^ event, tsm_NET::State^ nextState) override {
-		return exit((C)context, (E)event, (S)nextState);
-	}
+	virtual HRESULT handleEventCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState) override;
+	virtual HRESULT entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState) override;
+	virtual HRESULT exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState) override;
 #pragma endregion
 
 	S getMasterState() { return (S)tsm_NET::State::getMasterState(); }

--- a/StateMachine.NET/GenericObject.h
+++ b/StateMachine.NET/GenericObject.h
@@ -11,6 +11,7 @@ generic<typename E, typename S>
 public ref class Context : public tsm_NET::Context
 {
 public:
+	Context(bool isAsync) : tsm_NET::Context(isAsync) {}
 	virtual ~Context() {}
 
 	HResult setup(S initialState, E event) { return tsm_NET::Context::setup((tsm_NET::State^)initialState, (tsm_NET::Event^)event); }

--- a/StateMachine.NET/GenericObject.h
+++ b/StateMachine.NET/GenericObject.h
@@ -11,7 +11,8 @@ generic<typename E, typename S>
 public ref class Context : public tsm_NET::Context
 {
 public:
-	Context(bool isAsync) : tsm_NET::Context(isAsync) {}
+	Context() : tsm_NET::Context(true) {}
+	Context(bool isAsync ) : tsm_NET::Context(isAsync) {}
 	virtual ~Context() {}
 
 	HResult setup(S initialState, E event) { return tsm_NET::Context::setup((tsm_NET::State^)initialState, (tsm_NET::Event^)event); }

--- a/StateMachine.NET/NativeObjects.cpp
+++ b/StateMachine.NET/NativeObjects.cpp
@@ -20,25 +20,25 @@ Context::Context(ManagedType^ context, bool isAsync /*= true*/)
 }
 
 State::State(ManagedType^ state, ManagedType^ masterState)
-	: tsm::State<Context, Event, State>(getNative(masterState))
-	, m_managedState(state)
+	: m_managedState(state)
 	, m_handleEventCallback(state, gcnew ManagedType::HandleEventDelegate(state, &ManagedType::handleEventCallback))
 	, m_entryCallback(state, gcnew ManagedType::EntryDelegate(state, &ManagedType::entryCallback))
 	, m_exitCallback(state, gcnew ManagedType::ExitDelegate(state, &ManagedType::exitCallback))
+	, m_masterState(getNative(masterState))
 {
 }
 
-HRESULT State::handleEvent(Context* context, Event* event, State** nextState)
+HRESULT State::_handleEvent(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState)
 {
 	return m_handleEventCallback(context, event, nextState);
 }
 
-HRESULT State::entry(Context* context, Event* event, State* previousState)
+HRESULT State::_entry(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState)
 {
 	return m_entryCallback(context, event, previousState);
 }
 
-HRESULT State::exit(Context* context, Event* event, State* nextState)
+HRESULT State::_exit(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState)
 {
 	return m_exitCallback(context, event, nextState);
 }
@@ -47,15 +47,16 @@ Event::Event(ManagedType^ event)
 	: m_managedEvent(event)
 	, m_preHandleCallback(event, gcnew ManagedType::PreHandleDelegate(event, &ManagedType::preHandleCallback))
 	, m_postHandleCallback(event, gcnew ManagedType::PostHandleDelegate(event, &ManagedType::postHandleCallback))
+	, m_timerClient(nullptr)
 {
 }
 
-HRESULT Event::preHandle(Context* context)
+HRESULT Event::_preHandle(tsm::IContext* context)
 {
 	return m_preHandleCallback(context);
 }
 
-HRESULT Event::postHandle(Context* context, HRESULT hr)
+HRESULT Event::_postHandle(tsm::IContext* context, HRESULT hr)
 {
 	return m_postHandleCallback(context, hr);
 }

--- a/StateMachine.NET/NativeObjects.cpp
+++ b/StateMachine.NET/NativeObjects.cpp
@@ -14,7 +14,8 @@ struct TimerHandle {};
 }
 
 Context::Context(ManagedType^ context, bool isAsync /*= true*/)
-	: m_managedContext(context)
+	: m_isAsync(isAsync)
+	, m_managedContext(context)
 {
 }
 

--- a/StateMachine.NET/NativeObjects.h
+++ b/StateMachine.NET/NativeObjects.h
@@ -51,17 +51,19 @@ protected:
 	C callback;
 };
 
-class Context : public tsm::AsyncContext<Event, State>
+class Context : public tsm::Context<Event, State>
 {
 public:
 	using ManagedType = tsm_NET::Context;
 
 	Context(ManagedType^ context, bool isAsync = true);
+	virtual bool isAsync() const override { return m_isAsync; }
 
 	ManagedType^ get() { return m_managedContext; }
 
 protected:
 	gcroot<ManagedType^> m_managedContext;
+	bool m_isAsync;
 };
 
 class State : public tsm::State<Context, Event, State>

--- a/StateMachine.NET/NativeObjects.h
+++ b/StateMachine.NET/NativeObjects.h
@@ -51,7 +51,7 @@ protected:
 	C callback;
 };
 
-class Context : public tsm::Context<Event, State>
+class Context : public tsm::IContext, public tsm::TimerClient
 {
 public:
 	using ManagedType = tsm_NET::Context;
@@ -59,25 +59,56 @@ public:
 	Context(ManagedType^ context, bool isAsync = true);
 	virtual bool isAsync() const override { return m_isAsync; }
 
+	HRESULT setup(tsm::IState* initialState, tsm::IEvent* event = nullptr) { return _getStateMachine()->setup(this, initialState, event); }
+	HRESULT shutdown(DWORD timeout = 100) { return _getStateMachine()->shutdown(this, timeout); }
+	HRESULT triggerEvent(tsm::IEvent* event) { return _getStateMachine()->triggerEvent(this, event); }
+	HRESULT handleEvent(tsm::IEvent* event) { return _getStateMachine()->handleEvent(this, event); }
+	HRESULT waitReady(DWORD timeout = 100) { return _getStateMachine()->waitReady(this, timeout); }
+
+	virtual tsm::IStateMachine* _getStateMachine() override {
+		if(!m_stateMachine) m_stateMachine.reset(tsm::IStateMachine::create(this));
+		return m_stateMachine.get();
+	}
+	virtual tsm::IState* _getCurrentState() override { return m_currentState; }
+	virtual void _setCurrentState(tsm::IState* state) override { m_currentState = state; }
+
+	virtual tsm::IStateMonitor* _getStateMonitor() override { return nullptr; }
+
+	// Implementation of IContext::_getTimerClient().
+	virtual TimerClient* _getTimerClient() override { return this; }
+
 	ManagedType^ get() { return m_managedContext; }
+
+	inline State* getCurrentState() { return (State*)_getCurrentState(); }
 
 protected:
 	gcroot<ManagedType^> m_managedContext;
 	bool m_isAsync;
+
+	std::unique_ptr<tsm::IStateMachine> m_stateMachine;
+	CComPtr<tsm::IState> m_currentState;
 };
 
-class State : public tsm::State<Context, Event, State>
+class State : public tsm::IState, public tsm::TimerClient
 {
 public:
 	using ManagedType = tsm_NET::State;
 
 	State(ManagedType^ state, ManagedType^ masterState);
 
-#pragma region Methods that call method of Managed State class.
-	virtual HRESULT handleEvent(Context* context, Event* event, State** nextState) override;
-	virtual HRESULT entry(Context* context, Event* event, State* previousState) override;
-	virtual HRESULT exit(Context* context, Event* event, State* nextState) override;
+#pragma region Implementation of IState that call methods of managed class.
+	virtual HRESULT _handleEvent(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState) override;
+	virtual HRESULT _entry(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState) override;
+	virtual HRESULT _exit(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState) override;
+
+	virtual bool _callExitOnShutdown() const override { return false; }
+	virtual IState* _getMasterState() const override { return m_masterState; }
+
+	virtual TimerClient* _getTimerClient() override { return this; }
 #pragma endregion
+
+	inline State* getMasterState() const { return (State*)_getMasterState(); }
+	bool isSubState() const { return m_masterState ? true : false; }
 
 	ManagedType^ get() { return m_managedState; }
 
@@ -87,19 +118,26 @@ protected:
 	Callback<ManagedType, ManagedType::HandleEventDelegate, ManagedType::HandleEventCallback> m_handleEventCallback;
 	Callback<ManagedType, ManagedType::EntryDelegate, ManagedType::EntryCallback> m_entryCallback;
 	Callback<ManagedType, ManagedType::ExitDelegate, ManagedType::ExitCallback> m_exitCallback;
+
+	CComPtr<State> m_masterState;
 };
 
-class Event : public tsm::Event<Context>
+class Event : public tsm::IEvent
 {
 public:
 	using ManagedType = tsm_NET::Event;
 
 	Event(ManagedType^ event);
 
-#pragma region Methods that call method of Managed Event class.
-	virtual HRESULT preHandle(Context* context) override;
-	virtual HRESULT postHandle(Context* context, HRESULT hr) override;
+#pragma region Implementation of IState that call methods of managed class.
+	virtual HRESULT _preHandle(tsm::IContext* Icontext) override;
+	virtual HRESULT _postHandle(tsm::IContext* Icontext, HRESULT hr) override;
 #pragma endregion
+
+	virtual int _getPriority() const override { return m_priority; }
+	virtual DWORD _getDelayTime() const override { return m_delayTime; }
+	virtual DWORD _getIntervalTime() const override { return m_intervalTime; }
+	virtual tsm::TimerClient* _getTimerClient() const override { return m_timerClient; }
 
 	ManagedType^ get() { return m_managedEvent; }
 
@@ -108,6 +146,11 @@ protected:
 
 	Callback<ManagedType, ManagedType::PreHandleDelegate, ManagedType::PreHandleCallback> m_preHandleCallback;
 	Callback<ManagedType, ManagedType::PostHandleDelegate, ManagedType::PostHandleCallback> m_postHandleCallback;
+
+	int m_priority;
+	DWORD m_delayTime;
+	DWORD m_intervalTime;
+	tsm::TimerClient* m_timerClient;
 };
 
 }

--- a/StateMachine.NET/StateMachine.NET.cpp
+++ b/StateMachine.NET/StateMachine.NET.cpp
@@ -7,9 +7,9 @@
 using namespace tsm_NET;
 using namespace tsm_NET::common;
 
-Context::Context()
+Context::Context(bool isAsync)
 {
-	m_nativeContext = new native::Context(this);
+	m_nativeContext = new native::Context(this, isAsync);
 }
 
 Context::~Context()

--- a/StateMachine.NET/StateMachine.NET.cpp
+++ b/StateMachine.NET/StateMachine.NET.cpp
@@ -98,7 +98,7 @@ HRESULT State::entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IS
 
 HRESULT State::exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState)
 {
-	return (HRESULT)entry(getManaged((native::Context*)context), getManaged((native::Event*)event), getManaged((native::State*)nextState));
+	return (HRESULT)exit(getManaged((native::Context*)context), getManaged((native::Event*)event), getManaged((native::State*)nextState));
 }
 
 State^ State::getMasterState()

--- a/StateMachine.NET/StateMachine.NET.cpp
+++ b/StateMachine.NET/StateMachine.NET.cpp
@@ -7,7 +7,7 @@
 using namespace tsm_NET;
 using namespace tsm_NET::common;
 
-Context::Context(bool isAsync)
+void Context::construct(bool isAsync)
 {
 	m_nativeContext = new native::Context(this, isAsync);
 }

--- a/StateMachine.NET/StateMachine.NET.cpp
+++ b/StateMachine.NET/StateMachine.NET.cpp
@@ -81,24 +81,24 @@ State::!State()
 	}
 }
 
-HRESULT State::handleEventCallback(native::Context* context, native::Event* event, native::State** nextState)
+HRESULT State::handleEventCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState)
 {
 	State^ _nextState = nullptr;
-	auto hr = handleEvent(getManaged(context), getManaged(event), _nextState);
+	auto hr = handleEvent(getManaged((native::Context*)context), getManaged((native::Event*)event), _nextState);
 	if(_nextState) {
 		*nextState = getNative(_nextState);
 	}
 	return (HRESULT)hr;
 }
 
-HRESULT State::entryCallback(native::Context* context, native::Event* event, native::State* previousState)
+HRESULT State::entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState)
 {
-	return (HRESULT)entry(getManaged(context), getManaged(event), getManaged(previousState));
+	return (HRESULT)entry(getManaged((native::Context*)context), getManaged((native::Event*)event), getManaged((native::State*)previousState));
 }
 
-HRESULT State::exitCallback(native::Context* context, native::Event* event, native::State* nextState)
+HRESULT State::exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState)
 {
-	return (HRESULT)entry(getManaged(context), getManaged(event), getManaged(nextState));
+	return (HRESULT)entry(getManaged((native::Context*)context), getManaged((native::Event*)event), getManaged((native::State*)nextState));
 }
 
 State^ State::getMasterState()
@@ -138,12 +138,12 @@ Event::!Event()
 	}
 }
 
-HRESULT Event::preHandleCallback(native::Context* context)
+HRESULT Event::preHandleCallback(tsm::IContext* context)
 {
-	return (HRESULT)preHandle(getManaged(context));
+	return (HRESULT)preHandle(getManaged((native::Context*)context));
 }
 
-HRESULT Event::postHandleCallback(native::Context* context, HRESULT hr)
+HRESULT Event::postHandleCallback(tsm::IContext* context, HRESULT hr)
 {
-	return (HRESULT)postHandle(getManaged(context), (HResult)hr);
+	return (HRESULT)postHandle(getManaged((native::Context*)context), (HResult)hr);
 }

--- a/StateMachine.NET/StateMachine.NET.h
+++ b/StateMachine.NET/StateMachine.NET.h
@@ -126,11 +126,11 @@ internal:
 #pragma region Definition of delegate, callback signature and callback method. See tsm::ICallback<> template class.
 	delegate HRESULT PreHandleDelegate(tsm::IContext* context);
 	typedef HRESULT(__stdcall *PreHandleCallback)(tsm::IContext* context);
-	HRESULT preHandleCallback(tsm::IContext* context);
+	virtual HRESULT preHandleCallback(tsm::IContext* context);
 
 	delegate HRESULT PostHandleDelegate(tsm::IContext* context, HRESULT hr);
 	typedef HRESULT(__stdcall *PostHandleCallback)(tsm::IContext* context, HRESULT hr);
-	HRESULT postHandleCallback(tsm::IContext* context, HRESULT hr);
+	virtual HRESULT postHandleCallback(tsm::IContext* context, HRESULT hr);
 #pragma endregion
 
 protected:

--- a/StateMachine.NET/StateMachine.NET.h
+++ b/StateMachine.NET/StateMachine.NET.h
@@ -87,15 +87,15 @@ internal:
 #pragma region Definition of delegate, callback signature and callback method. See native::Callback<> template class.
 	delegate HRESULT HandleEventDelegate(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
 	typedef HRESULT (__stdcall *HandleEventCallback)(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
-	HRESULT handleEventCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
+	virtual HRESULT handleEventCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
 
 	delegate HRESULT EntryDelegate(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
 	typedef HRESULT (__stdcall *EntryCallback)(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
-	HRESULT entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
+	virtual HRESULT entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
 
 	delegate HRESULT ExitDelegate(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
 	typedef HRESULT(__stdcall *ExitCallback)(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
-	HRESULT exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
+	virtual HRESULT exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
 #pragma endregion
 
 protected:

--- a/StateMachine.NET/StateMachine.NET.h
+++ b/StateMachine.NET/StateMachine.NET.h
@@ -27,7 +27,7 @@ public ref class Context
 public:
 	using NativeType = native::Context;
 
-	Context();
+	Context(bool isAsync);
 	virtual ~Context();
 	!Context();
 

--- a/StateMachine.NET/StateMachine.NET.h
+++ b/StateMachine.NET/StateMachine.NET.h
@@ -85,17 +85,17 @@ internal:
 	NativeType* get() { return m_nativeState; }
 
 #pragma region Definition of delegate, callback signature and callback method. See native::Callback<> template class.
-	delegate HRESULT HandleEventDelegate(native::Context* context, native::Event* event, native::State** nextState);
-	typedef HRESULT (__stdcall *HandleEventCallback)(native::Context* context, native::Event* event, native::State** nextState);
-	HRESULT handleEventCallback(native::Context* context, native::Event* event, native::State** nextState);
+	delegate HRESULT HandleEventDelegate(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
+	typedef HRESULT (__stdcall *HandleEventCallback)(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
+	HRESULT handleEventCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState** nextState);
 
-	delegate HRESULT EntryDelegate(native::Context* context, native::Event* event, native::State* previousState);
-	typedef HRESULT (__stdcall *EntryCallback)(native::Context* context, native::Event* event, native::State* previousState);
-	HRESULT entryCallback(native::Context* context, native::Event* event, native::State* previousState);
+	delegate HRESULT EntryDelegate(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
+	typedef HRESULT (__stdcall *EntryCallback)(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
+	HRESULT entryCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* previousState);
 
-	delegate HRESULT ExitDelegate(native::Context* context, native::Event* event, native::State* nextState);
-	typedef HRESULT(__stdcall *ExitCallback)(native::Context* context, native::Event* event, native::State* nextState);
-	HRESULT exitCallback(native::Context* context, native::Event* event, native::State* nextState);
+	delegate HRESULT ExitDelegate(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
+	typedef HRESULT(__stdcall *ExitCallback)(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
+	HRESULT exitCallback(tsm::IContext* context, tsm::IEvent* event, tsm::IState* nextState);
 #pragma endregion
 
 protected:
@@ -123,14 +123,14 @@ public:
 internal:
 	NativeType* get() { return m_nativeEvent; }
 
-#pragma region Definition of delegate, callback signature and callback method. See native::Callback<> template class.
-	delegate HRESULT PreHandleDelegate(native::Context* context);
-	typedef HRESULT(__stdcall *PreHandleCallback)(native::Context* context);
-	HRESULT preHandleCallback(native::Context* context);
+#pragma region Definition of delegate, callback signature and callback method. See tsm::ICallback<> template class.
+	delegate HRESULT PreHandleDelegate(tsm::IContext* context);
+	typedef HRESULT(__stdcall *PreHandleCallback)(tsm::IContext* context);
+	HRESULT preHandleCallback(tsm::IContext* context);
 
-	delegate HRESULT PostHandleDelegate(native::Context* context, HRESULT hr);
-	typedef HRESULT(__stdcall *PostHandleCallback)(native::Context* context, HRESULT hr);
-	HRESULT postHandleCallback(native::Context* context, HRESULT hr);
+	delegate HRESULT PostHandleDelegate(tsm::IContext* context, HRESULT hr);
+	typedef HRESULT(__stdcall *PostHandleCallback)(tsm::IContext* context, HRESULT hr);
+	HRESULT postHandleCallback(tsm::IContext* context, HRESULT hr);
 #pragma endregion
 
 protected:

--- a/StateMachine.NET/StateMachine.NET.h
+++ b/StateMachine.NET/StateMachine.NET.h
@@ -24,10 +24,13 @@ public enum class HResult : int
 
 public ref class Context
 {
+	void construct(bool isAsync);
+
 public:
 	using NativeType = native::Context;
 
-	Context(bool isAsync);
+	Context() { construct(true); }
+	Context(bool isAsync) { construct(isAsync); }
 	virtual ~Context();
 	!Context();
 

--- a/StateMachine.NET/StateMachine.NET.vcxproj
+++ b/StateMachine.NET/StateMachine.NET.vcxproj
@@ -132,6 +132,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="GenericObject.h" />
     <ClInclude Include="NativeObjects.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="StateMachine.NET.h" />
@@ -139,6 +140,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
+    <ClCompile Include="GenericObject.cpp" />
     <ClCompile Include="NativeObjects.cpp" />
     <ClCompile Include="StateMachine.NET.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/StateMachine.NET/stdafx.h
+++ b/StateMachine.NET/stdafx.h
@@ -1,7 +1,5 @@
 #pragma once
 #include <StateMachine/stdafx.h>
-#include <StateMachine/Context.h>
-#include <StateMachine/State.h>
-#include <StateMachine/Event.h>
+#include <StateMachine/TimerClient.h>
 
 #include <vcclr.h>


### PR DESCRIPTION
Add generic classes of StateMachine.NET project.
 * Add isAsync parameter to tsm_NET.Context constructor.
 * Change base class of native Context, State and Event from template class to interface so that generic State/Event class can call methods of it's subclass directly.